### PR TITLE
Fix tags for the admin user

### DIFF
--- a/rabbitmq/server/user.sls
+++ b/rabbitmq/server/user.sls
@@ -11,7 +11,7 @@ rabbit_user_admin_present:
   - name: {{ server.admin.name }}
   - password: {{ server.admin.password }}
   - force: True
-  - tags: management administrator
+  - tags: administrator
   - perms:
     {%- for vhost_name, vhost in server.get('host', {}).iteritems() %}
     - '{{ vhost_name }}':


### PR DESCRIPTION
This is a temporary workaround because the rabbitmq Salt module
doesn't handle properly a list of tags.