### PR TITLE
Don't load amqp_client plugin explicitly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,6 @@ RabbitMQ as AMQP broker with admin user and vhosts
           name: adminuser
           password: pwd
         plugins:
-        - amqp_client
         - rabbitmq_management
         virtual_hosts:
         - enabled: true

--- a/metadata/service/server/cluster.yml
+++ b/metadata/service/server/cluster.yml
@@ -17,7 +17,6 @@ parameters:
           address: ${_param:cluster_local_address}
           port: 15672
       plugins:
-      - amqp_client
       - rabbitmq_management
       admin:
         name: admin

--- a/metadata/service/server/container.yml
+++ b/metadata/service/server/container.yml
@@ -20,7 +20,6 @@ parameters:
                     address: 0.0.0.0
                     port: 15672
                 plugins:
-                - amqp_client
                 - rabbitmq_management
                 admin:
                   name: admin

--- a/metadata/service/server/local.yml
+++ b/metadata/service/server/local.yml
@@ -19,7 +19,6 @@ parameters:
           address: 127.0.0.1
           port: 15672
       plugins:
-      - amqp_client
       - rabbitmq_management
       admin:
         name: ${_param:rabbitmq_admin_user}

--- a/metadata/service/server/single.yml
+++ b/metadata/service/server/single.yml
@@ -19,7 +19,6 @@ parameters:
           address: 0.0.0.0
           port: 15672
       plugins:
-      - amqp_client
       - rabbitmq_management
       admin:
         name: ${_param:rabbitmq_admin_user}


### PR DESCRIPTION
It's automatically loaded as a part of rabbitmq_management. And there is
actually no way to use it from outside (except for writing some
`rabbitmqctl eval` monstrosity).