### PR TITLE
Adjust stats collector settings

### DIFF
--- a/rabbitmq/files/rabbitmq.config
+++ b/rabbitmq/files/rabbitmq.config
@@ -19,6 +19,7 @@
               {cluster_nodes, {[{% for node in cluster.members %}'rabbit@{{ node.name }}'{% if not loop.last %}, {% endif %}{% endfor %}], {{ cluster.mode }}}},
               {%- endif %}
               {loopback_users, []},
+              {collect_statistics_interval, {{ server.collect_statistics_interval }}},
               {tcp_listeners, [{"{{ server.bind.address }}",{{ server.bind.port }}}]}
               {%- if server.get('ssl', {}).get('enabled', False) %},
               {ssl_listeners, [{"{{ server.bind.get('ssl', {}).get('address', server.bind.address) }}",{{ server.bind.get('ssl', {}).get('port', 5671) }}}]},
@@ -37,7 +38,9 @@
     }
     {%- if 'rabbitmq_management' in server.plugins %},
     {rabbitmq_management,
-              [{listener, [{port, {{ server.management.bind.port }} },
+              [{dummy_param_that_will_be_ignored, {but_itll_allow_easy_options_reordering, without_bothering_with_commas}}
+              ,{rates_mode, {{ server.rates_mode }}}
+              ,{listener, [{port, {{ server.management.bind.port }} },
                            {ip, "{{ server.management.bind.address }}" }
                            {%- if server.management.get('ssl', {}).get('enabled', False) %},
                            {ssl,true},

--- a/rabbitmq/map.jinja
+++ b/rabbitmq/map.jinja
@@ -1,5 +1,9 @@
 
 {% set server = salt['grains.filter_by']({
+    'default': {
+        'collect_statistics_interval': 30000,
+        'rates_mode': 'none',
+    },
     'Arch': {
         'pkgs': ['rabbitmq'],
         'service': 'rabbitmq',
@@ -67,7 +71,7 @@
             },
         },
     },
-}, merge=pillar.rabbitmq.get('server', {})) %}
+}, merge=pillar.rabbitmq.get('server', {}), base='default') %}
 
 {% set cluster = pillar.rabbitmq.get('cluster', {}) %}
 


### PR DESCRIPTION
Under heavy load the stats collector can fall behind while calculating
data that nobody actualy cares about.

Default values are taken from https://bugs.launchpad.net/fuel/+bug/1510835