### PR TITLE
Disable non-tls listener if ssl is enabled

### DIFF
--- a/rabbitmq/files/rabbitmq.config
+++ b/rabbitmq/files/rabbitmq.config
@@ -19,8 +19,8 @@
               {cluster_nodes, {[{% for node in cluster.members %}'rabbit@{{ node.name }}'{% if not loop.last %}, {% endif %}{% endfor %}], {{ cluster.mode }}}},
               {%- endif %}
               {loopback_users, []},
-              {tcp_listeners, [{"{{ server.bind.address }}",{{ server.bind.port }}}]}
               {%- if server.get('ssl', {}).get('enabled', False) %},
+              {tcp_listeners, []},
               {ssl_listeners, [{"{{ server.bind.get('ssl', {}).get('address', server.bind.address) }}",{{ server.bind.get('ssl', {}).get('port', 5671) }}}]},
               {ssl_options, [{cacertfile,"{{ server.ssl.ca_file }}"},
                              {certfile,"{{ server.ssl.cert_file }}"},
@@ -32,6 +32,8 @@
                              {%- endif %}
                              {fail_if_no_peer_cert,false}]}
 
+              {% else %}
+              {tcp_listeners, [{"{{ server.bind.address }}",{{ server.bind.port }}}]}
               {% endif %}
 
              ]


### PR DESCRIPTION
Non-tls listener should be disabled if SSL is turned on.