### PR TITLE
Allow setting the priority for a rabbitmq policy

### DIFF
--- a/rabbitmq/server/vhost.sls
+++ b/rabbitmq/server/vhost.sls
@@ -33,6 +33,7 @@ rabbitmq_policy_{{ host_name }}_{{ policy.name }}:
   - name: {{ policy.name }}
   - pattern: {{ policy.pattern }}
   - definition: {{ policy.definition|json }}
+  - priority: {{ policy.get('priority', 0)|int }}
   - vhost: {{ host_name }}
   - require:
     - service: rabbitmq_service


### PR DESCRIPTION
Because ordering does not always do the trick, a priority would be nice to be set.