### PR TITLE
Fix for issue #39. Cluster setting cluster_partition_handling

### DIFF
--- a/rabbitmq/files/rabbitmq.config
+++ b/rabbitmq/files/rabbitmq.config
@@ -5,7 +5,7 @@
               {disk_free_limit, {{ server.disk_free_limit }}},
               {%- if pillar.rabbitmq.cluster is defined %}
               {%- from "rabbitmq/map.jinja" import cluster with context %}
-              {cluster_partition_handling, autoheal},
+              {cluster_partition_handling, {{ cluster.cluster_partition_handling }}},
               {tcp_listen_options,
                         [binary,
                           {packet, raw},

--- a/rabbitmq/map.jinja
+++ b/rabbitmq/map.jinja
@@ -43,8 +43,11 @@
     },
 }, merge=pillar.rabbitmq.get('server', {}), base='default') %}
 
-{% set cluster = pillar.rabbitmq.get('cluster', {}) %}
-
+{% set cluster = salt['grains.filter_by']({
+  'default': {
+    'cluster_partition_handling': 'autoheal',
+  },
+}, merge=salt['pillar.get']('rabbitmq:cluster'), base='default') %}
 {%- set rabbitmq_users = {} %}
 {%- for host_name, host in server.get('host', {}).iteritems() %}
 {%- do rabbitmq_users.update({host.user: [host]}) %}


### PR DESCRIPTION
This is the pull request for #39 and will also fix #37. Cluster setting cluster_partition_handling can now be changed via pillars. In regular the default value for cluster_partition_handling is ignore (see https://www.rabbitmq.com/configure.html#configuration-file), however this formula used autoheal as default in the past. So i would recommend to keep it on autoheal (see change in map.jinja), if a change of this value is need this can now be done via pillars.

example pillars:
```
rabbitmq:
  server:
    enabled: true
    bind:
      address: 0.0.0.0
      port: 5672
    secret_key: rabbit_master_cookie
    admin:
      name: adminuser
      password: pwd
    memory:
      vm_high_watermark: 0.4
    plugins:
      - amqp_client
      - rabbitmq_management
  cluster:
    enabled: true
    role: master
    mode: disc
    cluster_partition_handling: ignore
    members:
    - name: openstack1
      host: 10.10.10.212
    - name: openstack2
      host: 10.10.10.213

```