### PR TITLE
add ulimit nofile configuration for rabbitmq process in systemd

### DIFF
--- a/rabbitmq/files/limits.conf
+++ b/rabbitmq/files/limits.conf
@@ -1,0 +1,4 @@
+{%- from "rabbitmq/map.jinja" import server with context -%}
+# Managed by Salt
+[Service]
+LimitNOFILE={{ server.ulimit }}

--- a/rabbitmq/map.jinja
+++ b/rabbitmq/map.jinja
@@ -12,6 +12,7 @@
         'env_file': '/etc/rabbitmq/rabbitmq-env.conf',
         'cookie_file': '/var/lib/rabbitmq/.erlang.cookie',
         'ulimit': 8192,
+        'limits_file': '/etc/systemd/system/rabbitmq-server.service.d/limits.conf',
         'disk_free_limit': 50000000,
         'bind': {
             'address': '0.0.0.0',


### PR DESCRIPTION
This pull request is for ulimit setting if systemd is used as init system. So all newer distributions supported to set ulimit now. Merge was tested with Debian and Centos.

please also see here: https://www.rabbitmq.com/install-debian.html (With systemd Recent Linux Distributions)