### PR TITLE
Remove dependency on the linux formula

### DIFF
--- a/rabbitmq/cluster.sls
+++ b/rabbitmq/cluster.sls
@@ -2,7 +2,6 @@
 {%- if cluster.enabled %}
 
 include:
-- linux.network.host
 - rabbitmq.server.service
 
 {% if cluster.get('role', 'None') == 'master' %}


### PR DESCRIPTION
This is preventing the standalone use of the rabbitmq formula.