### PR TITLE
Set rabbitmq user for enabling plugins

### DIFF
--- a/rabbitmq/server/plugin.sls
+++ b/rabbitmq/server/plugin.sls
@@ -9,6 +9,7 @@ include:
 rabbitmq_plugin_{{ plugin }}:
   rabbitmq_plugin.enabled:
   - name: {{ plugin }}
+  - runas: rabbitmq
   - require:
     - service: rabbitmq_service
 


### PR DESCRIPTION
There is currently a permission issue when enabling plugins. 
As in https://github.com/saltstack/salt/blob/6086ee452725c83044064a881ddabbc7895909a4/salt/modules/rabbitmq.py#L1004, the command to enable plugins is ran as 'runas' user, and if not set, with the same user as salt. For rabbitmq there is normally a separate rabbitmq user, and we can overwrite the default behaviour by setting 'runas' to that user.