### PR TITLE
Revert "Set rabbitmq user for enabling plugins"

### DIFF
--- a/rabbitmq/server/plugin.sls
+++ b/rabbitmq/server/plugin.sls
@@ -9,7 +9,6 @@ include:
 rabbitmq_plugin_{{ plugin }}:
   rabbitmq_plugin.enabled:
   - name: {{ plugin }}
-  - runas: rabbitmq
   - require:
     - service: rabbitmq_service
 


### PR DESCRIPTION
Reverts salt-formulas/salt-formula-rabbitmq#48

Revert as it brokes upstream code, please make the user configurable and keep backward compatibility.
Thanks