### PR TITLE
Adjust standalone example so it works

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ RabbitMQ as AMQP broker with admin user and vhosts
     rabbitmq:
       server:
         enabled: true
+        memory:
+          vm_high_watermark: 0.4
         bind:
           address: 0.0.0.0
           port: 5672


### PR DESCRIPTION
As per #47 `memory` is missing from the standalone example. I hit this issue and it stopped me for a while before I figured it out.

This is a PR to make the adjustment, and is what I did to get it working.