### PR TITLE
Update cluster example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,12 @@ RabbitMQ as base cluster node:
     rabbitmq:
       server:
         enabled: true
+        master: openstack1
+        {% if grains['host'] == 'openstack1' %}
+        role: master
+        {% else %}
+        role: slave
+        {% endif %}
         bind:
           address: 0.0.0.0
           port: 5672


### PR DESCRIPTION
I've spent last 1.5 day to troubleshoot why this didn't work.

By reverse engineer and try and error i finally found it that the documentation miss some key parts.

```
cluster:
  master: <master node to join against>
  role: <master|slave>
```