### PR TITLE
Ignore the case that erlang cookie is not created yet on clean install

### DIFF
--- a/rabbitmq/server/service.sls
+++ b/rabbitmq/server/service.sls
@@ -53,7 +53,7 @@ rabbitmq_limits_systemd:
 
 {%- if server.secret_key is defined and not grains.get('noservices', False) %}
 
-{%- if salt['cmd.shell']('cat '+server.cookie_file) != server.secret_key %}
+{%- if not salt['file.file_exists'](server.cookie_file) or salt['cmd.shell']('cat '+server.cookie_file) != server.secret_key %}
 
 sleep_before_rabbitmq_stop:
   cmd.run:


### PR DESCRIPTION
When the states are executed for the first time, it can occur that no erlang cookie exists yet. That isn't a problem, but the states then throws the following errors:
```
2019-07-01 14:54:03,444 [salt.loaded.int.module.cmdmod:826 ][ERROR   ][1005] Command 'cat /var/lib/rabbitmq/.erlang.cookie' failed with return code: 1
2019-07-01 14:54:03,445 [salt.loaded.int.module.cmdmod:828 ][ERROR   ][1005] stdout: cat: /var/lib/rabbitmq/.erlang.cookie: No such file or directory
```
This gives the impression that something went wrong, while that is not the case.

This change accounts for that scenario.