### PR TITLE
chore(py3): update jinja scripts

### DIFF
--- a/rabbitmq/map.jinja
+++ b/rabbitmq/map.jinja
@@ -50,7 +50,7 @@
   },
 }, merge=salt['pillar.get']('rabbitmq:cluster'), base='default') %}
 {%- set rabbitmq_users = {} %}
-{%- for host_name, host in server.get('host', {}).iteritems() %}
+{%- for host_name, host in server.get('host', {}).items() %}
 {%- do rabbitmq_users.update({host.user: [host]}) %}
 {%- endfor %}
 {%- set monitoring = salt['grains.filter_by']({

--- a/rabbitmq/server/user.sls
+++ b/rabbitmq/server/user.sls
@@ -13,7 +13,7 @@ rabbit_user_admin_present:
   - force: True
   - tags: administrator
   - perms:
-    {%- for vhost_name, vhost in server.get('host', {}).iteritems() %}
+    {%- for vhost_name, vhost in server.get('host', {}).items() %}
     - '{{ vhost_name }}':
       - '.*'
       - '.*'

--- a/rabbitmq/server/vhost.sls
+++ b/rabbitmq/server/vhost.sls
@@ -1,7 +1,7 @@
 {%- from "rabbitmq/map.jinja" import server with context %}
 {%- if server.enabled %}
 
-{%- for host_name, host in server.get('host', {}).iteritems() %}
+{%- for host_name, host in server.get('host', {}).items() %}
 
 {%- if host.enabled %}
 


### PR DESCRIPTION
Update Jinja scripts to use `items()` in place of `iteritems()`